### PR TITLE
Add custom license file

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,5 @@
+Copyright © 2025 Adam Cain, Andi Widianto, Kristin Schumann, Mirza Hamad Sultan. All rights reserved.
+
+This project was created for the University of London CM3030 - Games Development module.
+Use, copying, modification, or distribution is permitted only by the designated group members and relevant University staff for assessment purposes.
+No other rights are granted.


### PR DESCRIPTION
This pull request adds a new license file to clarify the usage rights and restrictions for the project. The license specifies that only designated group members and relevant University staff may use, copy, modify, or distribute the project, and that it was created for the University of London CM3030 - Games Development module.

* Licensing and usage clarification:
  * Added `LICENCE.md` file detailing copyright ownership, permitted usage, and restrictions for assessment purposes.