### PR TITLE
Add Global URP Settings

### DIFF
--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ec995e51a6e251468d2a3fd8a686257, type: 3}
+  m_Name: UniversalRenderPipelineGlobalSettings
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 3
+  m_RenderingLayerNames:
+  - Default
+  m_ValidRenderingLayers: 1
+  lightLayerName0: 
+  lightLayerName1: 
+  lightLayerName2: 
+  lightLayerName3: 
+  lightLayerName4: 
+  lightLayerName5: 
+  lightLayerName6: 
+  lightLayerName7: 
+  m_StripDebugVariants: 1
+  m_StripUnusedPostProcessingVariants: 0
+  m_StripUnusedVariants: 1
+  m_StripUnusedLODCrossFadeVariants: 1
+  m_StripScreenCoordOverrideVariants: 1
+  supportRuntimeDebugDisplay: 0
+  m_ShaderVariantLogLevel: 0
+  m_ExportShaderVariants: 1

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset.meta
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18dc0cd2c080841dea60987a38ce93fa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request adds a new global settings asset for the Universal Render Pipeline (URP) to the project. This asset configures important rendering options and enables the project to use URP-specific features.

Universal Render Pipeline configuration:

* Added `UniversalRenderPipelineGlobalSettings.asset`, which sets up rendering layer names, variant stripping options, and other URP global settings. This is essential for enabling and customizing URP in the project.
* Added corresponding `.meta` file for the new URP global settings asset to ensure correct asset tracking and import in Unity.