### PR TITLE
Feature/add cleanup files

### DIFF
--- a/Assets/Project/ThirdParty/Grusome_Zombie_AnimSet.meta
+++ b/Assets/Project/ThirdParty/Grusome_Zombie_AnimSet.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c45287ebe156634c9743b22f949d57b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/ThirdParty/Polygon Arsenal.meta
+++ b/Assets/Project/ThirdParty/Polygon Arsenal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2bc74b4579a547f40b8c05948e10ea78
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/ThirdParty/Synty.meta
+++ b/Assets/Project/ThirdParty/Synty.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff76744e08e28544a8ca86fccba900f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/ThirdParty/Synty/AnimationBaseLocomotion.meta
+++ b/Assets/Project/ThirdParty/Synty/AnimationBaseLocomotion.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fc7100860365bc4a853e7c11a0e7888
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/ThirdParty/Synty/PolygonApocalypse.meta
+++ b/Assets/Project/ThirdParty/Synty/PolygonApocalypse.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d558d45b3c2b7545995f505580ffce5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Project/ThirdParty/Synty/PolygonZombies.meta
+++ b/Assets/Project/ThirdParty/Synty/PolygonZombies.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 29cb1515d8ca6a5418d860d98c96384b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request adds meta files for several third-party asset folders in the Unity project. These meta files are necessary for Unity to properly track and manage the imported assets and their associated metadata.

New meta files for third-party assets:

* Synty asset folders:
  - Added `Synty.meta` to track the main Synty folder.
  - Added `AnimationBaseLocomotion.meta` for the Synty animation base locomotion assets.
  - Added `PolygonApocalypse.meta` for the Synty Polygon Apocalypse asset pack.
  - Added `PolygonZombies.meta` for the Synty Polygon Zombies asset pack.

* Other third-party assets:
  - Added `Grusome_Zombie_AnimSet.meta` for the Grusome Zombie Animation Set folder.
  - Added `Polygon Arsenal.meta` for the Polygon Arsenal asset pack folder.