### PR TITLE
Save Scene for Player Controller addition

### DIFF
--- a/Assets/Project/Scenes/Sandbox.unity
+++ b/Assets/Project/Scenes/Sandbox.unity
@@ -1143,7 +1143,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1572098767}
-  - component: {fileID: 1572098771}
   - component: {fileID: 1572098770}
   - component: {fileID: 1572098773}
   - component: {fileID: 1572098768}
@@ -1223,36 +1222,9 @@ CapsuleCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
-  m_Height: 1
+  m_Height: 2
   m_Direction: 1
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &1572098771
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1572098766}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 84
-  m_CollisionDetection: 1
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!114 &1572098772
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1266,6 +1238,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moveSpeed: 2
+  gravity: -9.81
   groundLayer:
     serializedVersion: 2
     m_Bits: 64
@@ -1296,7 +1269,7 @@ CharacterController:
   m_StepOffset: 0.3
   m_SkinWidth: 0.08
   m_MinMoveDistance: 0.001
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Center: {x: 0, y: 1, z: 0}
 --- !u!1 &2135225469
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This pull request makes several adjustments to the player character setup in the `Sandbox.unity` scene, focusing on collider configuration, physics components, and movement parameters. The main changes include removing the `Rigidbody` component, updating the `CapsuleCollider` and `CharacterController` settings, and adding a gravity parameter to the movement script.

Physics and Collider Configuration:

* Removed the `Rigidbody` component from the player GameObject, likely to rely solely on the `CharacterController` for movement and physics interactions.
* Updated the `CapsuleCollider`'s `m_Height` from 1 to 2 and shifted its `m_Center` from `{x: 0, y: 0, z: 0}` to `{x: 0, y: 1, z: 0}` for better alignment with the character model.
* Adjusted the `CharacterController`'s `m_Center` to `{x: 0, y: 1, z: 0}` for consistent collider positioning.

Movement and Gravity:

* Added a `gravity` parameter (set to -9.81) to the player movement script, allowing for customizable gravity effects in code.